### PR TITLE
산업기능요원(현역) 분류를 보충역으로 변경

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -151,12 +151,6 @@ export const SERVICES = [
   },
   {
     type: 'active',
-    length: 34,
-    value: 'industrialActive',
-    label: '산업기능요원(현역)'
-  },
-  {
-    type: 'active',
     length: 18,
     value: 'katusa',
     label: '카투사'
@@ -172,6 +166,12 @@ export const SERVICES = [
     length: 23,
     value: 'industrialReserve',
     label: '산업기능요원(보충역)'
+  },
+  {
+    type: 'reserve',
+    length: 34,
+    value: 'industrialActive',
+    label: '산업기능요원(현역)'
   },
   {
     type: 'reserve',


### PR DESCRIPTION
산업기능요원 현역의 경우 신체등위상으로만 현역으로 분리되지 실제적으로 보충역과 동일한 훈련을 받게 됩니다.
복무가 종료되고 소집해제가 되어도 보충역과 같은 이병 소총수로 분류되어 예비군 훈련을 받게 되므로 현역에 있는 것 보단 보충역으로 분류되는 것이 나중에 확장성을 위해 좋을 것 같아서 분리 하였습니다.
실제로 병무청에서도 현역 산업기능요원의 경우에도 편입 이후에 보충역과 같이 분류하고 있습니다.